### PR TITLE
using SafeMath for uint256 lets us express math operators more naturally

### DIFF
--- a/contracts/StakeableToken.sol
+++ b/contracts/StakeableToken.sol
@@ -3,6 +3,8 @@ pragma solidity ^0.4.23;
 import "./UTXORedeemableToken.sol";
 
 contract StakeableToken is UTXORedeemableToken {
+    using SafeMath for uint256;
+
     event Mint(address indexed _address, uint _reward);
 
     uint256 launchTime;
@@ -28,10 +30,10 @@ contract StakeableToken is UTXORedeemableToken {
     function stake(uint256 _value, uint256 _unlockTime) public {
         require(staked[msg.sender].amount == 0);
         require(_value <= balances[msg.sender]);
-        balances[msg.sender] = SafeMath.sub(balances[msg.sender], _value);
+        balances[msg.sender] = balances[msg.sender].sub(_value);
         staked[msg.sender] = stakeStruct(uint128(_value), block.timestamp, _unlockTime, stakers, stakedCoins);
-        stakers = SafeMath.add(stakers, 1);
-        stakedCoins = SafeMath.add(stakedCoins, _value);
+        stakers = stakers.add(1);
+        stakedCoins = stakedCoins.add(_value);
     }
 
     function calculateLazyRewards() public view returns (uint256) {
@@ -59,8 +61,8 @@ contract StakeableToken is UTXORedeemableToken {
     function mint() public returns (bool) {
         require(staked[msg.sender].amount > 0);
         require(block.timestamp > staked[msg.sender].unlockTime);
-        stakers = SafeMath.sub(stakers, 1);
-        stakedCoins = SafeMath.sub(stakedCoins, staked[msg.sender].amount);
+        stakers = stakers.sub(1);
+        stakedCoins = stakedCoins.sub(staked[msg.sender].amount);
         uint256 rewards = calculateRewards();
         delete staked[msg.sender];
         emit Mint(msg.sender, rewards);

--- a/contracts/UTXORedeemableToken.sol
+++ b/contracts/UTXORedeemableToken.sol
@@ -25,6 +25,7 @@ import "./MerkleProof.sol";
 * Based on https://github.com/ProjectWyvern/wyvern-ethereum
 */
 contract UTXORedeemableToken is StandardToken {
+    using SafeMath for uint256;
 
     /* Root hash of the UTXO Merkle tree, must be initialized by token constructor. */
     bytes32 public rootUTXOMerkleTreeHash;
@@ -210,16 +211,16 @@ contract UTXORedeemableToken is StandardToken {
         redeemedUTXOs[merkleLeafHash] = true;
 
         /* Calculate the redeemed tokens. */
-        tokensRedeemed = SafeMath.mul(satoshis, multiplier);
+        tokensRedeemed = satoshis.mul(multiplier);
 
         /* Track total redeemed tokens. */
-        totalRedeemed = SafeMath.add(totalRedeemed, tokensRedeemed);
+        totalRedeemed = totalRedeemed.add(tokensRedeemed);
 
         /* Sanity check. */
         require(totalRedeemed <= maximumRedeemable);
 
         /* Credit the redeemer. */ 
-        balances[msg.sender] = SafeMath.add(balances[msg.sender], tokensRedeemed);
+        balances[msg.sender] = balances[msg.sender].add(tokensRedeemed);
 
         /* Mark the transfer event. */
         emit Transfer(address(0), msg.sender, tokensRedeemed);
@@ -256,10 +257,7 @@ contract UTXORedeemableToken is StandardToken {
             s
         );
 
-        balances[referrer] = SafeMath.add(
-            balances[referrer],
-            SafeMath.div(claimAmount, 20)
-        );
+        balances[referrer] = balances[referrer].add( claimAmount.div(20) );
 
         return claimAmount;
     }


### PR DESCRIPTION
// For example, instead of...
SafeMath.mul( SafeMath.add( someNumber, someOtherNumber ), someMultiple );

// we can say
someNumber.add(someOtherNumber).mul( someMultiple );